### PR TITLE
[Tests] add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ node_js:
   - "8"
   - "7"
   - "6"
+before_script:
+  - 'if [ -n "${REACT-}" ] && [ "${TEST-}" = true ]; then sh install-relevant-react.sh && npm ls >/dev/null; fi'
 script:
-  - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
-  - 'if [ "${TEST-}" = true ]; then npm run test ; fi'
+  - 'if [ -n "${LINT-}" ]; then npm run lint; fi'
+  - 'if [ "${TEST-}" = true ]; then npm run test:only; fi'
 env:
   global:
     - TEST=true
   matrix:
-    - REACT=0.13
     - REACT=0.14
     - REACT=15
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+node_js:
+  - "8"
+  - "7"
+  - "6"
+script:
+  - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
+  - 'if [ "${TEST-}" = true ]; then npm run test ; fi'
+env:
+  global:
+    - TEST=true
+  matrix:
+    - REACT=0.13
+    - REACT=0.14
+    - REACT=15
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+      env: LINT=true TEST=false

--- a/compile.js
+++ b/compile.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-unresolved
 module.exports = require('./dist/compile');

--- a/install-relevant-react.sh
+++ b/install-relevant-react.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+REACT=${REACT:-15}
+
+echo "installing React $REACT"
+
+if [ "$REACT" = "0.14" ]; then
+  npm run react:14
+fi
+
+if [ "$REACT" = "15" ]; then
+  npm run react:15
+fi

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-airbnb": "^2.2.3",
     "chai": "^4.0.2",
     "enzyme": "^2.8.2",
-    "eslint": "^4.1.1",
+    "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.6.1",
     "jest": "^20.0.4",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,14 @@
   "scripts": {
     "build": "babel src --out-dir dist",
     "dev": "npm run build -- --watch",
-    "test": "jest",
     "lint": "eslint .",
+    "pretest": "npm run lint",
+    "test:only": "jest",
+    "test": "npm run test:only",
     "clean": "rimraf dist/ stylesheet.css",
+    "react:clean": "npm uninstall --no-save react react-dom react-addons-test-utils react-test-renderer && rimraf node_modules/react-test-renderer node_modules/react && npm prune",
+    "react:14": "rimraf node_modules/.bin/npm && npm run react:clean && npm i --no-save react@0.14 react-dom@0.14 react-addons-test-utils@0.14 && npm prune",
+    "react:15": "rimraf node_modules/.bin/npm && npm run react:clean && npm i --no-save react@15 react-dom@15 react-addons-test-utils@15 react-test-renderer@15 && npm prune",
     "veryclean": "npm run clean && rimraf node_modules/ babelCache/",
     "prepublish": "safe-publish-latest"
   },
@@ -28,8 +33,7 @@
     "global-cache": "^1.2.0",
     "jsdom": "^11.0.0",
     "object.entries": "^1.0.4",
-    "object.values": "^1.0.4",
-    "react-dom": "^15.6.0"
+    "object.values": "^1.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -40,11 +44,17 @@
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.6.1",
     "jest": "^20.0.4",
-    "react": "^15.6.0",
-    "react-test-renderer": "^15.5.4",
+    "react": "^0.14 || ^15.6.0",
+    "react-dom": "^0.14 || ^15.6.0",
+    "react-test-renderer": "^0.14 || ^15.5.4",
     "react-with-styles": "^1.4.0",
     "rimraf": "^2.6.1",
     "safe-publish-latest": "^1.1.1",
     "webpack": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14 || ^15.6.0",
+    "react-dom": "^0.14 || ^15.6.0",
+    "react-with-styles": "^1.4.0"
   }
 }


### PR DESCRIPTION
Reverts airbnb/react-with-styles-interface-css#3

Revert of a revert! In this PR though, we'll be adding back the relevant react version scripts that @ljharb mentioned previously.

I added an `install-relevant-react` bash script, going off of what we currently have in `react-dates`. I also moved the `react` dependencies to be peer deps (to allow for supporting react 14). Unfortunately, `react-with-styles` only supports react 14 and 15 and so this interface is going to have to support the same versions.