### PR TITLE
Add registerMaxSpecificity method and clean up compile tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 babelCache/
+bin/
 
 # Logs
 logs

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-jest": "^21.2.0",
     "babel-preset-airbnb": "^2.2.3",
     "chai": "^4.0.2",
+    "dashify": "^0.2.2",
     "enzyme": "^2.8.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -59,5 +59,20 @@ function registerCSSInterfaceNamespace(CSSInterfaceNamespace) {
   }
 }
 
+/**
+ * Register max specificity for generating CSS
+ *
+ * maxSpecificity {Integer} max specificity to use for generating stylesheets,
+ *   ie how many _N classes get generated
+ */
+function registerMaxSpecificity(maxSpecificity) {
+  const sharedState = globalCache.get(GLOBAL_CACHE_KEY);
+  if (!sharedState) {
+    globalCache.set(GLOBAL_CACHE_KEY, { maxSpecificity });
+  } else {
+    sharedState.maxSpecificity = maxSpecificity;
+  }
+}
+
 export default { create, resolve };
-export { registerCSSInterfaceNamespace };
+export { registerCSSInterfaceNamespace, registerMaxSpecificity };

--- a/src/utils/compile.js
+++ b/src/utils/compile.js
@@ -24,16 +24,20 @@ let oldDocument;
 let oldReactDOMRender;
 let oldCSSInterfaceCreate;
 
+function resetCSS() {
+  CSS = '';
+}
+
 function getCSS(stylesObject) {
   const sharedState = globalCache.get(GLOBAL_CACHE_KEY) || {};
 
   const styleSheet = StyleSheet.create(stylesObject);
   entries(styleSheet).forEach(([styleName, styleSheetObject]) => {
-    const { namespace = '' } = sharedState;
+    const { namespace = '', maxSpecificity = MAX_SPECIFICITY } = sharedState;
     const className = getClassName(namespace, styleName);
 
     let extendedClassName = `${className}`;
-    for (let i = 1; i <= MAX_SPECIFICITY; i += 1) {
+    for (let i = 1; i <= maxSpecificity; i += 1) {
       const repeatedSpecifier = `.${className}_${i}`.repeat(i);
       extendedClassName += `,${repeatedSpecifier}`;
     }
@@ -81,6 +85,7 @@ function cleanupCompilationEnvironment() {
 export {
   CSS,
   getCSS,
+  resetCSS,
   noopReactDOMRender,
   prepareCompilationEnvironment,
   cleanupCompilationEnvironment,


### PR DESCRIPTION
This allows the ability to change the default specificity of selectors from 20 to anything else. This is especially useful when debugging.

to: @ljharb @lencioni @airbnb/webinfra 