### PR TITLE
Return StyleSheet.create from getCSS util

### DIFF
--- a/packages/compiler/src/utils.js
+++ b/packages/compiler/src/utils.js
@@ -59,6 +59,7 @@ function getCSS(stylesObject) {
 
   // Prepend newCSS so the entry point styles appear at the top of the stylesheet
   CSS = newCSS + CSS;
+  return {};
 }
 
 function prepareCompilationEnvironment() {

--- a/packages/compiler/test/utils_test.js
+++ b/packages/compiler/test/utils_test.js
@@ -22,6 +22,10 @@ describe('getCSS', () => {
     resetCSS();
   });
 
+  it('returns an empty object', () => {
+    expect(getCSS({})).to.deep.equal({});
+  });
+
   it('returns expected styles', () => {
     const stylesObject = {
       primary: {


### PR DESCRIPTION
Because we are now actually "rendering" each of the components when we build our stylesheet, we run into problems if `getCSS` (which is monkeypatching into the create method) does not return an object. This addresses that issue.

to: @ljharb 