### PR TITLE
fix(ie11): replace Object.assign with object spread operators.

### DIFF
--- a/packages/interface/src/utils/separateStyles.js
+++ b/packages/interface/src/utils/separateStyles.js
@@ -7,7 +7,7 @@ function separateStyles(stylesArray) {
   // keys, and we want the best performance in this code because we are in the
   // render path, we are going to do a little bookkeeping ourselves.
   let hasInlineStyles = false;
-  const inlineStyles = {};
+  let inlineStyles = {};
 
   // This is run on potentially every node in the tree when rendering, where
   // performance is critical. Normally we would prefer using `forEach`, but
@@ -23,7 +23,7 @@ function separateStyles(stylesArray) {
       if (typeof style === 'string') {
         classNames.push(style);
       } else {
-        Object.assign(inlineStyles, style);
+        inlineStyles = { ...inlineStyles, ...style }
         hasInlineStyles = true;
       }
     }


### PR DESCRIPTION
`Object.assign` is not supported on IE11