### PR TITLE
[compiler] Update react-with-styles-interface-css 5 -> 6

### DIFF
--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,3 +1,6 @@
+Unpublished
+- [new][deps] Update `react-with-styles-interface-css` ^5.0.0 -> ^6.0.0
+
 v2.1.0
 - [new][deps] Update `react-with-styles-interface-css` ^4.0.1 -> ^5.0.0
 - [dev deps] Update `react-with-styles` ^3.1.0 -> ^4.0.0

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -37,19 +37,17 @@
   "author": "Felipe Vargas <felipe@fvgs.ai> (fvgs.ai)",
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^7.1.2",
-    "@babel/core": "^7.1.2",
-    "@babel/runtime": "^7.5.5",
-    "babel-core": "^7.0.0-bridge.0",
-    "babel-jest": "^23.6.0",
-    "babel-preset-airbnb": "^3.0.1",
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "babel-jest": "^24.9.0",
+    "babel-preset-airbnb": "^4.0.1",
     "chai": "^4.2.0",
     "dashify": "^0.2.2",
     "eslint": "^5.6.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "in-publish": "^2.0.0",
-    "jest": "^23.6.0",
+    "jest": "^24.9.0",
     "react": "^0.14 || ^15.6.0 || ^16.1.1",
     "react-dom": "^0.14 || ^15.6.0 || ^16.1.1",
     "react-with-styles": "^4.0.0",
@@ -57,14 +55,15 @@
     "safe-publish-latest": "^1.1.2"
   },
   "dependencies": {
-    "@babel/register": "^7.0.0",
+    "@babel/register": "^7.5.5",
+    "@babel/runtime": "^7.5.5",
     "aphrodite": "^2.2.3",
     "clean-css": "^4.2.1",
     "global-cache": "^1.2.1",
     "jsdom": "^11.12.0",
     "object.entries": "^1.0.4",
     "object.values": "^1.0.4",
-    "react-with-styles-interface-css": "^5.0.0"
+    "react-with-styles-interface-css": "^6.0.0"
   },
   "peerDependencies": {
     "aphrodite": "^2.2.0",


### PR DESCRIPTION
### Summary

Update `react-with-styles-interface-interface-css` from 5 -> 6. The breaking change was the requirement of `@babel/runtime` as a peer dep, so we also make all the other updates required to update `babel-preset-airbnb` as well to keep them consistent.

Not a breaking change because we include `@babel/runtime` in the standalone tool's dependencies.

@ljharb @TaeKimJR @indiesquidge @ahuth @joeuy 