### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "react:14": "rimraf node_modules/.bin/npm && npm run react:clean && npm i --no-save react@0.14 react-dom@0.14 react-addons-test-utils@0.14 && npm prune",
     "react:15": "rimraf node_modules/.bin/npm && npm run react:clean && npm i --no-save react@15 react-dom@15 react-addons-test-utils@15 react-test-renderer@15 && npm prune"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/airbnb/react-with-styles-interface-css.git"
+  },
   "devDependencies": {
     "lerna": "^2.11.0",
     "react": "^0.14 || ^15.6.0 || ^16.1.1",

--- a/packages/compiler/index.js
+++ b/packages/compiler/index.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/no-unresolved
-module.exports = require('./dist/index.js').default;
+module.exports = require('./dist').default;

--- a/packages/interface/index.js
+++ b/packages/interface/index.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/no-unresolved
-module.exports = require('./dist/index.js').default;
+module.exports = require('./dist').default;


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
*react-with-styles-interface-css